### PR TITLE
Implemented non generic classes

### DIFF
--- a/src/CoTaskMemAllocater.cs
+++ b/src/CoTaskMemAllocater.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Runtime.InteropServices;
 
-namespace CapraLib.MemoryAllocater
+namespace CapraLib.MemoryLock
 {
     public class CoTaskMemAllocater<T> : IDisposable, IMemoryAllocater<T> where T : unmanaged
     {

--- a/src/GCAllocater.cs
+++ b/src/GCAllocater.cs
@@ -3,11 +3,11 @@ using System.Runtime.InteropServices;
 
 namespace CapraLib.MemoryAllocater
 {
-    public class ObjectPinner<T> : IDisposable, IMemoryAllocater<T> where T : unmanaged
+    public class GCAllocater<T> : IDisposable, IMemoryAllocater<T> where T : unmanaged
     {
         private GCHandle _handle;
 
-        public ObjectPinner(out IntPtr unmanaged, in T managed)
+        public GCAllocater(out IntPtr unmanaged, in T managed)
         {
             _handle = GCHandle.Alloc(managed, GCHandleType.Pinned);
             unmanaged = _handle.AddrOfPinnedObject();

--- a/src/GCAllocater.cs
+++ b/src/GCAllocater.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Runtime.InteropServices;
 
-namespace CapraLib.MemoryAllocater
+namespace CapraLib.MemoryLock
 {
     public class GCAllocater<T> : IDisposable, IMemoryAllocater<T> where T : unmanaged
     {

--- a/src/HGlobalAllocater.cs
+++ b/src/HGlobalAllocater.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Runtime.InteropServices;
 
-namespace CapraLib.MemoryAllocater
+namespace CapraLib.MemoryLock
 {
     public class HGlobalAllocater<T> : IDisposable, IMemoryAllocater<T> where T : unmanaged
     {

--- a/src/Interfaces/IMemoryAllocater.cs
+++ b/src/Interfaces/IMemoryAllocater.cs
@@ -1,7 +1,14 @@
+using System;
+
 namespace CapraLib.MemoryLock
 {
     public interface IMemoryAllocater<T> where T : unmanaged
     {
         void SetResult(out T managed);
+    }
+
+    public interface IMemoryAllocater
+    {
+        void SetResult(out Span<byte> bytes);
     }
 }

--- a/src/Interfaces/IMemoryAllocater.cs
+++ b/src/Interfaces/IMemoryAllocater.cs
@@ -1,4 +1,4 @@
-namespace CapraLib.MemoryAllocater
+namespace CapraLib.MemoryLock
 {
     public interface IMemoryAllocater<T> where T : unmanaged
     {

--- a/src/MemoryLock.csproj
+++ b/src/MemoryLock.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
   </PropertyGroup>
 
 </Project>

--- a/src/MemoryLock.csproj
+++ b/src/MemoryLock.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netcoreapp2.1</TargetFramework>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
 </Project>

--- a/src/NonGeneric/CoTaskMemAllocater.cs
+++ b/src/NonGeneric/CoTaskMemAllocater.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace CapraLib.MemoryLock
+{
+    public class CoTaskMemAllocater : IMemoryAllocater, IDisposable
+    {
+        private IntPtr _allocated;
+        private int _size;
+
+        public CoTaskMemAllocater(out IntPtr unmanaged, int size)
+        {
+            _allocated = unmanaged = Marshal.AllocCoTaskMem(size);
+            _size = size;
+        }
+
+        public void SetResult(out Span<byte> bytes)
+        {
+            unsafe
+            {
+                bytes = new Span<byte>((void*)_allocated, _size);
+            }
+        }
+
+        public void Dispose()
+        {
+            Marshal.FreeCoTaskMem(_allocated);
+        }
+    }
+}

--- a/src/NonGeneric/GCAllocater.cs
+++ b/src/NonGeneric/GCAllocater.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace CapraLib.MemoryLock
+{
+    public class GCAllocater : IMemoryAllocater, IDisposable
+    {
+        private GCHandle _handle;
+
+        public GCAllocater(out IntPtr unmanaged, object managed)
+        {
+            _handle = GCHandle.Alloc(managed, GCHandleType.Pinned);
+            unmanaged = _handle.AddrOfPinnedObject();
+        }
+
+        public void SetResult(out object managed)
+        {
+            managed = _handle.Target;
+        }
+
+        public void SetResult(out Span<byte> bytes)
+        {
+            unsafe
+            {
+                var size =  Marshal.SizeOf(_handle.Target.GetType());
+                bytes = new Span<byte>((void*)_handle.AddrOfPinnedObject(), size);
+            }
+        }
+
+        public void Dispose()
+        {
+            _handle.Free();
+        }
+    }
+}

--- a/src/NonGeneric/HGlobalAllocater.cs
+++ b/src/NonGeneric/HGlobalAllocater.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Runtime.InteropServices;
+
+namespace CapraLib.MemoryLock
+{
+    public class HGlobalAllocater : IMemoryAllocater, IDisposable
+    {
+        private IntPtr _allocated;
+        private int _size;
+
+        public HGlobalAllocater(out IntPtr unmanaged, int size)
+        {
+            _allocated = unmanaged = Marshal.AllocHGlobal(size);
+            _size = size;
+        }
+
+        public void SetResult(out Span<byte> bytes)
+        {
+            unsafe
+            {
+                bytes = new Span<byte>((void*)_allocated, _size);
+            }
+        }
+
+        public void Dispose()
+        {
+            Marshal.FreeCoTaskMem(_allocated);
+        }
+    }
+}

--- a/test/CoTaskMemAllocaterTest.cs
+++ b/test/CoTaskMemAllocaterTest.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 
 using Xunit;
 
-namespace CapraLib.MemoryAllocater.Test
+namespace CapraLib.MemoryLock.Test
 {
     public class CoTaskMemAllocaterTest
     {

--- a/test/GCAllocaterTest.cs
+++ b/test/GCAllocaterTest.cs
@@ -6,14 +6,14 @@ using Xunit;
 
 namespace CapraLib.MemoryAllocater.Test
 {
-    public class ObjectPinnerTest
+    public class GCAllocaterTest
     {
         #region Allocate Tests
 
         [Fact]
         public void AllocateInt()
         {
-            using(var allocated = new ObjectPinner<int>(out IntPtr unmanaged, 100))
+            using(var allocated = new GCAllocater<int>(out IntPtr unmanaged, 100))
             {
                 
             }
@@ -22,7 +22,7 @@ namespace CapraLib.MemoryAllocater.Test
         [Fact]
         public void AllocateDouble()
         {
-            using(var allocated = new ObjectPinner<double>(out IntPtr unmanaged, MathF.PI))
+            using(var allocated = new GCAllocater<double>(out IntPtr unmanaged, MathF.PI))
             {
                 
             }
@@ -31,7 +31,7 @@ namespace CapraLib.MemoryAllocater.Test
         [Fact]
         public void AllocateStruct()
         {
-            using(var allocated = new ObjectPinner<SampleStrcut>(out IntPtr unmanaged, new SampleStrcut()))
+            using(var allocated = new GCAllocater<SampleStrcut>(out IntPtr unmanaged, new SampleStrcut()))
             {
                 
             }
@@ -49,7 +49,7 @@ namespace CapraLib.MemoryAllocater.Test
         {
             int value = 100;
 
-            using(var allocated = new ObjectPinner<int>(out IntPtr unmanaged, value))
+            using(var allocated = new GCAllocater<int>(out IntPtr unmanaged, value))
             {
                 Marshal.WriteInt32(unmanaged, changeTo);
 
@@ -76,7 +76,7 @@ namespace CapraLib.MemoryAllocater.Test
         {
             var sample = new SampleStrcut();
 
-            using(var allocated = new ObjectPinner<SampleStrcut>(out IntPtr unmanaged, sample))
+            using(var allocated = new GCAllocater<SampleStrcut>(out IntPtr unmanaged, sample))
             {
                 Marshal.StructureToPtr(changeTo, unmanaged, fDeleteOld: false);
 

--- a/test/GCAllocaterTest.cs
+++ b/test/GCAllocaterTest.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 
 using Xunit;
 
-namespace CapraLib.MemoryAllocater.Test
+namespace CapraLib.MemoryLock.Test
 {
     public class GCAllocaterTest
     {

--- a/test/HGlobalAllocaterTest.cs
+++ b/test/HGlobalAllocaterTest.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 
 using Xunit;
 
-namespace CapraLib.MemoryAllocater.Test
+namespace CapraLib.MemoryLock.Test
 {
     public class HGlobalAllocaterTest
     {

--- a/test/MemoryLockTest.csproj
+++ b/test/MemoryLockTest.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>


### PR DESCRIPTION
I had implemented MemoryLock  only in generic classes. That means this library had not been used by passing the number of byte codes.
  
After this PR is merged, you can use the kind of APIs which is non generic.