### PR TITLE
Update Build_Nuget job to Pack job

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -59,6 +59,7 @@ jobs:
       PathtoPublish: $(Build.ArtifactStagingDirectory)
 - job: Pack
   displayName: "Pack"
+  condition: and(succeeded(), startsWith(variables['Build.SourceBranch'], 'refs/tags/'))
   pool:
     vmImage: "ubuntu-latest"
   steps:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -33,8 +33,8 @@ jobs:
       testResultsFormat: "VSTest"
       testResultsFiles: "**/*.trx"
     condition: succeededOrFailed()
-- job: Build_Library
-  displayName: "Build DLL"
+- job: Build
+  displayName: "Build"
   pool:
     vmImage: "ubuntu-latest"
   steps:
@@ -57,8 +57,8 @@ jobs:
     inputs:
       ArtifactName: "LibraryBuildOutput"
       PathtoPublish: $(Build.ArtifactStagingDirectory)
-- job: Build_Nuget
-  displayName: "Build Nuget"
+- job: Pack
+  displayName: "Pack"
   pool:
     vmImage: "ubuntu-latest"
   steps:


### PR DESCRIPTION
Build_Nuget job runs when some commits are pushed on master branch. I think it is not good because the package generated will never be published except there is a release.  
So I changed Build_Nuget job to Pack job, which runs only when a tag is pushed. 